### PR TITLE
fix: not adding names to path when only

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -175,9 +175,9 @@ function process_dict!(step::UnpackStep{N,T,C}, instruction_stack) where {N,T,C}
     names_num = length(child_nodes)
     if names_num == 0
         push!(instruction_stack, column_set_step(ColumnSet()))
-    elseif names_num > 1
-        push!(instruction_stack, merge_instruction(get_name(step), length(child_nodes), level))
+        return nothing
     end
+    push!(instruction_stack, merge_instruction(get_name(step), length(child_nodes), level))
 
     for child_node in child_nodes
         name = get_name(child_node)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,18 @@ const heterogenous_level_test_body = Dict(
         :b => 5
     )
     @test unordered_equal(EN.expand(empty_dict_field), (b = [5],))
+
+    @test begin
+        two_layer_deep = Dict(
+            :a => Dict(
+                :b => Dict(
+                    :c => 1,
+                    :d => 2,
+                )
+            )
+        )
+        unordered_equal(EN.expand(two_layer_deep), (a_b_c = [1], a_b_d = [2]))
+    end
 end
 
 


### PR DESCRIPTION
When there was two layers of nested dictionaries with one key each, it created a bug where the intermediate key names were not added to the path_keys. This adds back in a "merge" step for single key dictionaries to ensure each step's name is prepended to the path