### PR TITLE
clean up docstrings

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -102,7 +102,6 @@ tbl |> rows |> first
 
 ## API
 ```@docs
-ExpandNestedData.expand(::Any)
 ExpandNestedData.expand(::Any, ::Vector{ExpandNestedData.ColumnDefinition})
 ExpandNestedData.ColumnDefinition(::Any;)
 ```

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -18,7 +18,7 @@ Expand a nested data structure into a Tables
 * `lazy_columns::Bool` - If true, return columns using a lazy iterator. If false, `collect` into regular vectors before returning. Default: `true` (don't collect).
 * `pool_arrays::Bool` - If true, use pool arrays to `collect` the columns. Default: `false`.
 * `column_names::Dict{Tuple, Symbol}` - A lookup to replace column names in the final result with any other symbol
-* `column_style::Symbol` - Choose returned column style from `:nested` or `:flat`. If nested, `column\_names` are ignored 
+* `column_style::Symbol` - Choose returned column style from `:nested` or `:flat`. If nested, `column_names` are ignored 
     and a TypedTables.Table is returned in which the columns are nested in the same structure as the source data. Default: `:flat`
 * `name_join_pattern::String` - A pattern to put between the keys when joining the path into a column name. Default: `"_"`.
 ## Returns
@@ -42,10 +42,10 @@ function expand(data, column_definitions=nothing;
 
     expanded_table = ExpandedTable(columns, final_column_defs; lazy_columns = lazy_columns, pool_arrays = pool_arrays, column_style = typed_column_style, name_join_pattern=name_join_pattern)
 
-    final_table = if column_style == flat_columns
-        return as_flat_table(expanded_table)
-    elseif column_style == nested_columns
-        return as_nested_table(expanded_table)
+    final_table = if typed_column_style == flat_columns
+        as_flat_table(expanded_table)
+    elseif typed_column_style == nested_columns
+        as_nested_table(expanded_table)
     end
     return final_table
 end

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -11,14 +11,18 @@ using DataStructures: Stack
 
 Expand a nested data structure into a Tables
 
-Args:
+## Args:
 * data::Any - The nested data to unpack
-* column::Vector{ColumnDefinition} - A list of paths to follow in `data`, ignoring other branches. Optional. Default: `nothing`.
-* lazy_columns::Bool - If true, return columns using a lazy iterator. If false, `collect` into regular vectors before returning. Default: `true` (don't collect).
-* pool_arrays::Bool - If true, use pool arrays to `collect` the columns. Default: `false`.
-* column_names::Dict{Tuple, Symbol} - A lookup to replace column names in the final result with any other symbol
-* column_style::Symbol - Choose returned column style from `:nested` or `:flat`. If nested, `column_names` are ignored and a TypedTables.Table is returned in which the columns are nested in the same structure as the source data. Default: `:flat`
-* name_join_pattern::String - A pattern to put between the keys when joining the path into a column name. Default: `"_"`.
+* column_defs::Vector{ColumnDefinition} - A list of paths to follow in `data`, ignoring other branches. Optional. Default: `nothing`.
+## Kwargs:
+* `lazy_columns::Bool` - If true, return columns using a lazy iterator. If false, `collect` into regular vectors before returning. Default: `true` (don't collect).
+* `pool_arrays::Bool` - If true, use pool arrays to `collect` the columns. Default: `false`.
+* `column_names::Dict{Tuple, Symbol}` - A lookup to replace column names in the final result with any other symbol
+* `column_style::Symbol` - Choose returned column style from `:nested` or `:flat`. If nested, `column\_names` are ignored 
+    and a TypedTables.Table is returned in which the columns are nested in the same structure as the source data. Default: `:flat`
+* `name_join_pattern::String` - A pattern to put between the keys when joining the path into a column name. Default: `"_"`.
+## Returns
+`::NamedTuple`
 """
 function expand(data, column_definitions=nothing; 
         default_value = missing, 
@@ -36,7 +40,14 @@ function expand(data, column_definitions=nothing;
         construct_column_definitions(columns, column_names, pool_arrays, name_join_pattern) :
         column_definitions
 
-    return ExpandedTable(columns, final_column_defs; lazy_columns = lazy_columns, pool_arrays = pool_arrays, column_style = typed_column_style, name_join_pattern=name_join_pattern)
+    expanded_table = ExpandedTable(columns, final_column_defs; lazy_columns = lazy_columns, pool_arrays = pool_arrays, column_style = typed_column_style, name_join_pattern=name_join_pattern)
+
+    final_table = if column_style == flat_columns
+        return as_flat_table(expanded_table)
+    elseif column_style == nested_columns
+        return as_nested_table(expanded_table)
+    end
+    return final_table
 end
 
 """Wrap an object in the correct UnpackStep"""

--- a/src/ExpandTypes.jl
+++ b/src/ExpandTypes.jl
@@ -57,15 +57,15 @@ pool_arrays(c::ColumnDefinition) = c.pool_arrays
 ## Returns
 `::ColumnDefinition`
 """
+function ColumnDefinition(field_path; kwargs...)
+    return ColumnDefinition(tuple(field_path...); kwargs...)
+end
 function ColumnDefinition(field_path::T; column_name=nothing, default_value=missing, pool_arrays=false, name_join_pattern::String = "_") where {T <: Tuple}
     if column_name isa Nothing
         path = last(field_path) == :unnamed ? field_path[1:end-1] : field_path
         column_name = join_names(path, name_join_pattern)
     end
     ColumnDefinition(field_path, column_name, default_value, pool_arrays)
-end
-function ColumnDefinition(field_path; kwargs...)
-    return ColumnDefinition(tuple(field_path...); kwargs...)
 end
 function ColumnDefinition(field_path, column_names::Dict; pool_arrays::Bool, name_join_pattern = "_")
     column_name = field_path in keys(column_names) ? column_names[field_path] : nothing

--- a/src/ExpandedTable.jl
+++ b/src/ExpandedTable.jl
@@ -19,12 +19,6 @@ function ExpandedTable(columns::Dict{K, T}, column_defs::Vector{ColumnDefinition
         for def in column_defs
     )
     expanded_table = ExpandedTable(col_lookup, column_tuple)
-    
-    if column_style == flat_columns
-        return as_flat_table(expanded_table)
-    elseif column_style == nested_columns
-        return as_nested_table(expanded_table)
-    end
 end
 
 """Build a nested NamedTuple of TypedTables from the columns following the same nesting structure


### PR DESCRIPTION
Fix some issues with the docstring
- Underscores being treated as italics
- ColumnDefinition docstring associated with the wrong method
- Fix: Typo in column_style caused return `nothing` when `nested`