### PR TITLE
fix: full length tuple for missing_col_set

### DIFF
--- a/src/ColumnSet.jl
+++ b/src/ColumnSet.jl
@@ -79,9 +79,9 @@ get_column(cols::ColumnSet, name, default::NestedIterator) = name in keys(cols) 
 
 
 """Return a missing column for each member of a child path"""
-function make_missing_column_set(path_node, current_index)
+function make_missing_column_set(path_node)
     missing_column_set =  Dict(
-        path_to_value(value_node, current_index) => get_default(value_node)
+        field_path(value_node) => get_default(value_node)
         for value_node in get_all_value_nodes(path_node)
     )
     return missing_column_set

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -132,7 +132,7 @@ function process_array!(step::UnpackStep{N,T,C}, instruction_stack) where {N,T,C
         # If we have column defs, but the array is empty, that means we need to make a 
         # missing column_set
         next_step = !(C <: Union{SimpleNode, Nothing}) ?
-            column_set_step(make_missing_column_set(path_node, level)) :
+            column_set_step(make_missing_column_set(path_node)) :
             default_object(name, level, path_node)
         push!(instruction_stack, next_step)
         return nothing
@@ -202,7 +202,7 @@ function process_dict!(step::UnpackStep{N,T,C}, instruction_stack) where {N,T,C}
             wrap_object(name, child_data, level+1, child_node)
         # CASE 2: Expected a child node, but don't find it 
         elseif should_have_child && !data_has_name
-            column_set_step(make_missing_column_set(child_node, level+1))
+            column_set_step(make_missing_column_set(child_node))
         # CASE 3: We don't expect a child node: wrap any value in a new column
         elseif !should_have_child
             wrap_object(name, child_data, level+1, child_node, leaf)


### PR DESCRIPTION
Fixes an issue where very long column defs did not get a full path in their column name if they were missing from the input data