### PR TITLE
Code-cleaning

### DIFF
--- a/src/ColumnSet.jl
+++ b/src/ColumnSet.jl
@@ -3,12 +3,11 @@
 
 # Convenience alias for a dictionary of columns
 ColumnSet = Dict{Tuple, NestedIterator} 
-columnset(col, depth) = ColumnSet(Tuple(() for _ in 1:depth) => col)
-init_column_set(data, depth) = columnset(NestedIterator(data), depth)
+columnset(col, level) = ColumnSet(Tuple(() for _ in 1:level) => col)
 init_column_set(step) = init_column_set(get_data(step), get_name(step), get_level(step))
-function init_column_set(data, name, depth)
-    col_set = init_column_set(data, depth)
-    prepend_name!(col_set, name, depth)
+function init_column_set(data, name, level)
+    col_set = columnset(NestedIterator(data), level)
+    prepend_name!(col_set, name, level)
     return col_set
 end
 
@@ -27,15 +26,15 @@ function apply_in_place!(cols, f, args...)
 end
 
 """
-prepend_name!(cols, name, depth)
-Set the given name for all column keys at the given depth
+prepend_name!(cols, name, level)
+Set the given name for all column keys at the given level
 """
-function prepend_name!(cols, name, depth)
-    depth < 1 && return nothing
-    apply_in_place!(cols, _prepend_name, name, depth)
+function prepend_name!(cols, name, level)
+    level < 1 && return nothing
+    apply_in_place!(cols, _prepend_name, name, level)
 end
-function _prepend_name(key, val, name, depth)
-    new_key = Tuple(i==depth ? name : k for (i,k) in enumerate(key))
+function _prepend_name(key, val, name, level)
+    new_key = Tuple(i==level ? name : k for (i,k) in enumerate(key))
     return new_key, val
 end
 
@@ -81,7 +80,7 @@ get_column(cols::ColumnSet, name, default::NestedIterator) = name in keys(cols) 
 """Return a missing column for each member of a child path"""
 function make_missing_column_set(path_node)
     missing_column_set =  Dict(
-        field_path(value_node) => get_default(value_node)
+        get_field_path(value_node) => get_default(value_node)
         for value_node in get_all_value_nodes(path_node)
     )
     return missing_column_set

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -154,7 +154,7 @@ function process_array!(step::UnpackStep{N,T,C}, instruction_stack) where {N,T,C
     elseif element_count == 1
         push!(instruction_stack, wrap_object(name, first(arr), level, path_node))
         return nothing
-    elseif is_value_type(eltype(T))
+    elseif all_eltypes_are_values(T)
         push!(instruction_stack, column_set_step(init_column_set(arr, name, level)))
         return nothing
     end

--- a/src/ExpandTypes.jl
+++ b/src/ExpandTypes.jl
@@ -89,8 +89,3 @@ function make_column_def_child_copies(column_defs::Vector{ColumnDefinition}, nam
 end
 is_current_name(column_def::ColumnDefinition, name, level) = current_path_name(column_def, level) == name
 has_more_keys(column_def, level) = level < length(get_field_path(column_def))
-function append_name!(def, name)
-    new_field_path = tuple(get_field_path(def)..., name)
-    def.field_path = new_field_path
-    return def
-end

--- a/src/ExpandTypes.jl
+++ b/src/ExpandTypes.jl
@@ -37,10 +37,10 @@ mutable struct ColumnDefinition
     pool_arrays::Bool
 end
 # Accessors
-field_path(c::ColumnDefinition) = c.field_path
-column_name(c::ColumnDefinition) = c.column_name
-default_value(c::ColumnDefinition) = c.default_value
-pool_arrays(c::ColumnDefinition) = c.pool_arrays
+get_field_path(c::ColumnDefinition) = c.field_path
+get_column_name(c::ColumnDefinition) = c.column_name
+get_default_value(c::ColumnDefinition) = c.default_value
+get_pool_arrays(c::ColumnDefinition) = c.pool_arrays
 
 """
     ColumnDefinition(field_path; column_name=nothing, flatten_arrays=false, default_value=missing, pool_arrays=false)
@@ -49,7 +49,7 @@ pool_arrays(c::ColumnDefinition) = c.pool_arrays
 * `field_path`: Vector or Tuple of keys/fieldnames that constitute a path from the top of the data to the values to extract for the column
 
 ## Keyword Args
-* `column_name::Symbol`: A name for the resulting column. If `nothing`, defaults to joining the field_path with snake_case_format.
+* `column_name::Symbol`: A name for the resulting column. If `nothing`, defaults to joining the `field_path` with snake case format.
 * `flatten_arrays::Bool`: When a leaf node is an array, should the values be flattened into separate rows or treated as a single value. Default: `true`
 * `default_value`: When the field_path keys do not exist on one or more branches, fill with this value. Default: `missing`
 * `pool_arrays::Bool`: When collecting values for this column, choose whether to use `PooledArrays` instead of `Base.Vector`. Default: `false` (use `Vector`)
@@ -76,21 +76,21 @@ function construct_column_definitions(columns, column_names, pool_arrays, name_j
     return ColumnDefinition.(paths, Ref(column_names); pool_arrays=pool_arrays, name_join_pattern)
 end
 
-function current_path_name(c::ColumnDefinition, depth)
-    fp = field_path(c)
-    return fp[depth]
+function current_path_name(c::ColumnDefinition, level)
+    fp = get_field_path(c)
+    return fp[level]
 end
-get_unique_current_names(defs, depth) = unique((current_path_name(def, depth) for def in defs))
-function make_column_def_child_copies(column_defs::Vector{ColumnDefinition}, name, depth)
+get_unique_current_names(defs, level) = unique((current_path_name(def, level) for def in defs))
+function make_column_def_child_copies(column_defs::Vector{ColumnDefinition}, name, level)
     return filter(
-        def -> is_current_name(def, name, depth) && length(field_path(def)) > depth, 
+        def -> is_current_name(def, name, level) && length(get_field_path(def)) > level, 
         column_defs
         )
 end
-is_current_name(col_def::ColumnDefinition, name, depth) = current_path_name(col_def, depth) == name
-has_more_keys(col_def, depth) = depth < length(field_path(col_def))
+is_current_name(column_def::ColumnDefinition, name, level) = current_path_name(column_def, level) == name
+has_more_keys(column_def, level) = level < length(get_field_path(column_def))
 function append_name!(def, name)
-    new_field_path = tuple(field_path(def)..., name)
+    new_field_path = tuple(get_field_path(def)..., name)
     def.field_path = new_field_path
     return def
 end

--- a/src/ExpandTypes.jl
+++ b/src/ExpandTypes.jl
@@ -28,7 +28,7 @@ is_value_type(t::Type) = !is_container(t) && isconcretetype(t)
 ############################
 
 """ColumnDefinition provides a mechanism for specifying details for extracting data from a nested data source"""
-mutable struct ColumnDefinition
+struct ColumnDefinition
     # Path to values
     field_path::Tuple
     # name of this column in the table once expanded

--- a/src/ExpandedTable.jl
+++ b/src/ExpandedTable.jl
@@ -25,7 +25,7 @@ end
 as the source data"""
 function make_column_tuple(columns, path_graph::AbstractPathNode, lazy_columns::Bool)
     kvs = []
-    for child in children(path_graph)
+    for child in get_children(path_graph)
         push!(kvs, Symbol(get_name(child)) => make_column_tuple(columns, child, lazy_columns))
     end
 
@@ -33,11 +33,11 @@ function make_column_tuple(columns, path_graph::AbstractPathNode, lazy_columns::
     return Table(children_tuple)
 end
 function make_column_tuple(columns, path_graph::ValueNode, lazy_columns::Bool)
-    lazy_column = columns[field_path(path_graph)]
-    value_column =  lazy_columns ? lazy_column : collect(lazy_column, pool_arrays(path_graph))
-    if length(children(path_graph)) > 0
+    lazy_column = columns[get_field_path(path_graph)]
+    value_column =  lazy_columns ? lazy_column : collect(lazy_column, get_pool_arrays(path_graph))
+    if length(get_children(path_graph)) > 0
         d = Dict(:unnamed => value_column)
-        for child in children(path_graph)
+        for child in get_children(path_graph)
             d[Symbol(get_name(child))] = make_column_tuple(columns, child, lazy_columns)
         end
         return Table(NamedTuple(d))

--- a/src/ExpandedTable.jl
+++ b/src/ExpandedTable.jl
@@ -11,14 +11,13 @@ struct ExpandedTable
 end
 
 """Construct an ExpandedTable from the results of `create_columns`"""
-function ExpandedTable(columns::Dict{K, T}, column_defs::Vector{ColumnDefinition}; lazy_columns, column_style, kwargs...) where {K, T<: NestedIterator{<:Any}}
-    path_graph = make_path_graph(column_defs)
+function ExpandedTable(columns::Dict{K, T}, path_graph; lazy_columns, kwargs...) where {K, T<: NestedIterator{<:Any}}
     column_tuple = make_column_tuple(columns, path_graph, lazy_columns)
     col_lookup = Dict(
-        column_name(def) => field_path(def)
-        for def in column_defs
+        get_final_name(val_node) => get_field_path(val_node)
+        for val_node in get_all_value_nodes(path_graph)
     )
-    expanded_table = ExpandedTable(col_lookup, column_tuple)
+    return ExpandedTable(col_lookup, column_tuple)
 end
 
 """Build a nested NamedTuple of TypedTables from the columns following the same nesting structure

--- a/src/PathGraph.jl
+++ b/src/PathGraph.jl
@@ -96,7 +96,6 @@ function make_path_nodes!(column_defs, level = 1)
                 NestedIterator(get_default_value(without_child));
                 col_name=get_column_name(without_child))
             push!(child_nodes, value_column_node)
-            append_name!(without_child, :unnamed)
         end
 
         nodes[i] = PathNode(unique_name, child_nodes)
@@ -106,5 +105,5 @@ end
 
 
 """Create a graph of field_paths that models the structure of the nested data"""
-make_path_graph(col_defs::Vector{ColumnDefinition}) = PathNode(:TOP_LEVEL, make_path_nodes!(col_defs))
+make_path_graph(column_defs::Vector{ColumnDefinition}) = PathNode(:TOP_LEVEL, make_path_nodes!(column_defs))
 make_path_graph(::Nothing; _...) = nothing

--- a/src/PathGraph.jl
+++ b/src/PathGraph.jl
@@ -27,15 +27,16 @@ function ValueNode(name, field_path, pool_arrays, default; col_name)
     ValueNode(name, col_name, ValueNode[], field_path, pool_arrays,default)
 end
 
-children(n::AbstractPathNode) = n.children
+get_children(n::AbstractPathNode) = n.children
 get_name(n::AbstractPathNode) = n.name
-field_path(n::ValueNode) = n.field_path
-pool_arrays(n::ValueNode) = n.pool_arrays
+get_final_name(n::ValueNode) = n.final_name
+get_field_path(n::ValueNode) = n.field_path
+get_pool_arrays(n::ValueNode) = n.pool_arrays
 get_default(n::ValueNode) = n.default
 
-"""Given a certain depth index, return the rest of the path down to the value"""
+"""Given a certain level index, return the rest of the path down to the value"""
 function path_to_value(c::ValueNode, current_index)
-    fp = field_path(c)
+    fp = get_field_path(c)
     return fp[current_index:end]
 end
 
@@ -50,7 +51,7 @@ function get_all_value_nodes(node::T, ch) where {T}
         put!(ch, node)
         return nothing
     end
-    get_all_value_nodes.(children(node), Ref(ch))
+    get_all_value_nodes.(get_children(node), Ref(ch))
     return nothing
 end
 
@@ -60,12 +61,12 @@ end
 SIDE EFFECT: also appends :unnamed to any column defs that stop at a pathnode to capture any
 loose values in an array at that level
 """
-function make_path_nodes!(column_defs, depth = 1)
-    unique_names = get_unique_current_names(column_defs, depth)
+function make_path_nodes!(column_defs, level = 1)
+    unique_names = get_unique_current_names(column_defs, level)
     nodes = Vector{AbstractPathNode}(undef, length(unique_names))
     for (i, unique_name) in enumerate(unique_names)
-        matching_defs = filter(p -> current_path_name(p, depth) == unique_name, column_defs)
-        are_value_nodes = [!has_more_keys(def, depth) for def in matching_defs]
+        matching_defs = filter(p -> current_path_name(p, level) == unique_name, column_defs)
+        are_value_nodes = [!has_more_keys(def, level) for def in matching_defs]
         
         all_value_nodes = all(are_value_nodes)
         mix_of_node_types = !all_value_nodes && any(are_value_nodes)
@@ -74,26 +75,26 @@ function make_path_nodes!(column_defs, depth = 1)
             # If we got to a value node, there should only be one.
             def = first(matching_defs)
             nodes[i] = ValueNode(
-                unique_name, field_path(def), pool_arrays(def), NestedIterator(default_value(def));
-                col_name = column_name(def))
+                unique_name, get_field_path(def), get_pool_arrays(def), NestedIterator(get_default_value(def));
+                col_name = get_column_name(def))
             continue
         end
 
         with_children = !mix_of_node_types ? 
             matching_defs :
             [def for (is_value, def) in zip(are_value_nodes, matching_defs) if !is_value]
-        children_col_defs = make_column_def_child_copies(with_children, unique_name, depth)
+        children_column_defs = make_column_def_child_copies(with_children, unique_name, level)
 
-        child_nodes = make_path_nodes!(children_col_defs, depth+1)
+        child_nodes = make_path_nodes!(children_column_defs, level+1)
         if mix_of_node_types
             without_child_idx = findfirst(identity, are_value_nodes)
             without_child = matching_defs[without_child_idx]
             value_column_node = ValueNode(
                 :unnamed, 
-                (field_path(without_child)..., :unnamed), 
-                pool_arrays(without_child),
-                NestedIterator(default_value(without_child));
-                col_name=column_name(without_child))
+                (get_field_path(without_child)..., :unnamed), 
+                get_pool_arrays(without_child),
+                NestedIterator(get_default_value(without_child));
+                col_name=get_column_name(without_child))
             push!(child_nodes, value_column_node)
             append_name!(without_child, :unnamed)
         end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,12 +1,11 @@
-"""Check if any elements in an iterator are subtypes of NameValueContainer"""
-function has_namevaluecontainer_element(itr)
-    if eltype(itr) == Any
-        return itr .|> eltype .|> is_NameValueContainer |> any
-    else
-        return itr |> eltype |> get_member_types .|> is_NameValueContainer |> any
+"""Check if the eltype of a T are all value types (i.e. not containers)"""
+all_eltypes_are_values(::Type{T}) where T = all_is_value_type(eltype(T))
+function all_is_value_type(::Type{T}) where T
+    if T isa Union
+        return all(is_value_type.(Base.uniontypes(T)))
     end
+    return is_value_type(T)
 end
-get_member_types(::Type{T}) where T = T isa Union ? Base.uniontypes(T) : [T]
 
 
 """Get the keys/names of any NameValueContainer"""


### PR DESCRIPTION
Normalize naming conventions around `get_` for accessor functions. 
Consolidate "depth" and "index" type variables to "level" when referring to the level of the data structure or key path.
Make path_graph the driver for all logic navigating the data and column names. This allows ColumnDefinition to be immutable. 
Added docstrings to core algorithm functions