### PR TITLE
Refact: Exports for Internals

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -9,7 +9,7 @@ small_dict = Dict(
 
 many_records = [
     small_dict
-    for _ in 1:1000
+    for _ in 1:10000
 ]
 
 function make_deep_dict(depth=1)
@@ -21,12 +21,18 @@ function make_deep_dict(depth=1)
         for i in 1:3
     )
 end
+deep_dict = make_deep_dict(7)
                 
+# expand(small_dict; lazy_columns=true, column_style=:nested)
 # @btime expand($small_dict; lazy_columns=true, column_style=:nested)
 # @profview ExpandNestedData.expand(small_dict; lazy_columns=true, column_style=:nested);
-# deep_dict = make_deep_dict(10)
+
+# expand(deep_dict; lazy_columns=true, column_style=:nested);
 # @btime expand($deep_dict; lazy_columns=true, column_style=:nested);
+# @profview_allocs ExpandNestedData.expand(deep_dict; lazy_columns=true, column_style=:nested) sample_rate=0.01
+
+# expand(many_records; lazy_columns=true, column_style=:nested);
+# @btime expand($many_records; lazy_columns=true, column_style=:nested);
 # @descend expand(many_records; lazy_columns=true, column_style=:nested)
 # @profview ExpandNestedData.expand(many_records; lazy_columns=true, column_style=:nested)
 # @profview_allocs ExpandNestedData.expand(many_records; lazy_columns=true, column_style=:nested)
-# @btime expand($many_records; lazy_columns=true, column_style=:nested);

--- a/src/ColumnDefinitions.jl
+++ b/src/ColumnDefinitions.jl
@@ -1,8 +1,6 @@
 module ColumnDefinitions
 using ..ColumnSetManagers: ColumnSet, unnamed
 import ..join_names
-export ColumnDefinition, get_field_path, get_column_name, get_default_value, get_pool_arrays, make_column_def_child_copies, current_path_name, construct_column_definitions
-
 
 """ColumnDefinition provides a mechanism for specifying details for extracting data from a nested data source"""
 struct ColumnDefinition

--- a/src/ColumnSetManager.jl
+++ b/src/ColumnSetManager.jl
@@ -1,15 +1,11 @@
 module ColumnSetManagers
 using DataStructures: OrderedRobinDict, Stack
 using ..NameLists: NameID, NameList, top_level_id, unnamed_id, unnamed, max_id
-using ..NestedIterators
+import ..NestedIterators: RawNestedIterator, NestedIterator, cycle, repeat_each
+
 import ..get_name
 import ..get_id
 import ..collect_tuple
-export NameID, NameList, top_level_id, unnamed, unnamed_id
-export ColumnSet, cycle_columns_to_length!, repeat_each_column!, get_first_key, get_total_length, column_length, set_length!
-export ColumnSetManager, get_id, get_name, get_id_for_path, get_column_set, free_column_set!, build_final_column_set, init_column_set, reconstruct_field_path
-
-
 
 #### ColumnSet ####
 ###################

--- a/src/ColumnSetManager.jl
+++ b/src/ColumnSetManager.jl
@@ -175,7 +175,7 @@ function collect_name_ids(csm::ColumnSetManager, name_list::NameList)
         head = head.tail_i
     end
     # need to reverse field path because we stack the last on top as we descend through the data structure
-    return Iterators.reverse(csm.name_list_collector)
+    return reverse!(csm.name_list_collector)
 end
 
 
@@ -292,7 +292,7 @@ function apply_in_place!(cols, f, args...)
     for i in eachindex(cols)
         k, v = cols[i]
         val = f(v, args...)
-        cols[i] = Pair(k,val)
+        cols[i] = Pair{NameID, RawNestedIterator}(k,val)
     end
 end
 

--- a/src/ColumnSetManager.jl
+++ b/src/ColumnSetManager.jl
@@ -167,6 +167,8 @@ function get_id(csm::ColumnSetManager, name_list::NameList)
     return get_id(csm, path_tuple)
 end
 
+"""Return a vector of NameIDs based on the given NameList. CAREFUL the returned vector is a buffer which is overwritten the
+next time `collect_name_ids` is called."""
 function collect_name_ids(csm::ColumnSetManager, name_list::NameList)
     empty!(csm.name_list_collector)
     head::NameList = name_list
@@ -328,8 +330,5 @@ end
 Return the lowest value id key from a columnset
 """
 get_first_key(cs::ColumnSet) = length(cs) > 0 ? first(first(cs.cols)) : max_id
-
-
-
 
 end # ColumnSetManagers

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,3 +1,10 @@
+import .NestedIterators: RawNestedIterator, NestedVcat
+import .ColumnSetManagers: ColumnSet, cycle_columns_to_length!, repeat_each_column!, get_first_key, 
+                get_total_length, column_length, set_length!, free_column_set!, build_final_column_set
+import .PathGraph: make_path_graph, get_children, SimpleNode
+import .ColumnDefinitions: construct_column_definitions
+
+
 """
     expand(data, column_defs=nothing; 
             default_value = missing, 

--- a/src/CoreHelpers.jl
+++ b/src/CoreHelpers.jl
@@ -27,6 +27,8 @@ missing_column_set_step(csm, path_node) = NewColumnSetStep(make_missing_column_s
 init_column_set_step(csm, name_list, data) = NewColumnSetStep(init_column_set(csm, name_list, data))
 empty_column_set_step(csm) = NewColumnSetStep(get_column_set(csm))
 
+##### UnpackStep accessor Functions ###############
+###################################################
 function PathGraph.get_name(u::UnpackStep)
     return @cases u begin
         [DictStep,ArrayStep,LeafStep,DefaultStep](n) => n
@@ -85,16 +87,20 @@ function wrap_object(name::NameList, data::T, path_node::Node, step_type::S=noth
     return _step_type(name, data, path_node)
 end
 
+"""Create a New Default Col Step when not using ColumnDefinitions"""
 function empty_arr_simple!(name, instruction_stack)
     next_step = UnpackStep'.DefaultStep(name)
     push!(instruction_stack, next_step)
 end
 
+"""Create a New Default Col Step when using ColumnDefinitions"""
 function empty_arr_path!(csm, path_node, instruction_stack)
     next_step = missing_column_set_step(csm, path_node)
     push!(instruction_stack, next_step)
 end
 
+"""Decide if we have all containers (true/false) and no containers (true/false) in an array given the
+qualifications of ColumnDefinition"""
 function calculate_container_status_for_path_node(child_nodes, container_count)
     # for path nodes, we need to check if there is :unnamed (indicating that there should be loose values)
     # if so, override all_containers so we check for loose
@@ -105,6 +111,7 @@ function calculate_container_status_for_path_node(child_nodes, container_count)
     (false, container_count == 0)
 end
 
+"""Used in the context where we have a PathNode so it must be container, returnes a UnpackStep"""
 function wrap_container_val(data_has_name::Bool, name_list::NameList, data, node::Node, csm::ColumnSetManager)
     @debug "wrap_container val for" data=data 
     if data_has_name

--- a/src/CoreHelpers.jl
+++ b/src/CoreHelpers.jl
@@ -1,7 +1,8 @@
 using .PathGraph
 using .PathGraph: Node, get_all_value_nodes, get_field_path, get_default
-using .ColumnSetManagers
-using .ColumnSetManagers: ColumnSetManager, get_column_set, get_id_for_path, get_name
+using .ColumnSetManagers: ColumnSetManager, ColumnSet, get_column_set, 
+                    get_id_for_path, get_name, init_column_set
+import .NameLists: NameList, unnamed_id
 
 @sum_type UnpackStep :hidden begin
     DictStep(::NameList, ::Any, ::Node)

--- a/src/ExpandNestedData.jl
+++ b/src/ExpandNestedData.jl
@@ -8,8 +8,7 @@ using StructTypes
 using SumTypes
 using TypedTables: Table
 
-export expand
-export ColumnDefinition
+export expand, ColumnDefinition
 
 """NameValueContainer is an abstraction on Dict and DataType structs so that we can get their
 contents without worrying about `getkey` or `getproperty`, etc.
@@ -26,13 +25,12 @@ include("NameLists.jl")
 include("NestedIterators.jl")
 include("ColumnSetManager.jl")
 include("ColumnDefinitions.jl")
+import .ColumnDefinitions: ColumnDefinition
 include("PathGraph.jl")
-using .NestedIterators
-using .ColumnSetManagers
-using .ColumnDefinitions
-using .PathGraph
 include("ExpandedTable.jl")
-include("Core.jl")
 include("CoreHelpers.jl")
+
+# Here is where the main logic starts
+include("Core.jl")
 
 end

--- a/src/ExpandedTable.jl
+++ b/src/ExpandedTable.jl
@@ -1,3 +1,8 @@
+import .NestedIterators: NestedIterator
+import .NameLists: top_level_id
+import .PathGraph: Node, get_final_name, get_all_value_nodes, get_field_path
+import .ColumnSetManagers: reconstruct_field_path
+
 @enum ColumnStyle flat_columns nested_columns
 
 get_column_style(s::Symbol) = (flat=flat_columns, nested=nested_columns)[s]

--- a/src/NameLists.jl
+++ b/src/NameLists.jl
@@ -2,12 +2,14 @@ module NameLists
 #### Linked List for Key/Names ####
 ###################################
 # An ID refering to a key/name in the input
+"""Represents an ID for a name stored in a ColumnSetManager"""
 struct NameID
     id::Int64
 end
 Base.isless(n::NameID, o::NameID) = n.id < o.id
 
 # Points to current head of a NameList
+"""NameList is a node in a linked list of NameIDs"""
 struct NameList
     tail_i::Union{NameList, Nothing}
     i::NameID
@@ -16,7 +18,7 @@ NameList() = NameList(nothing, top_level_id)
 
 #### Constants ####
 ###################
-
+"""Represents a missing name ID"""
 const no_name_id = NameID(-1)
 """A NameID for TOP_LEVEL"""
 const top_level_id = NameID(0)

--- a/src/NestedIterators.jl
+++ b/src/NestedIterators.jl
@@ -5,7 +5,6 @@ using Compat
 using ..NameLists: NameID, no_name_id
 import ..get_name
 import ..get_id
-export RawNestedIterator, NestedIterator, seed, repeat_each, cycle, NestedVcat
 
 struct CaptureListNil end
 """A node in a linked list of captured iteration instructions"""
@@ -128,7 +127,7 @@ function cycle(c::RawNestedIterator, n)
 end
 
 """Captures the two getindex functions of vcated NestedIterators. f_len tells which index to break over to g."""
-struct Unvcat{F, G} <: InstructionCapture
+struct Unvcat{F, G} 
     f_len::Int64
     f::F
     g::G 

--- a/src/PathGraph.jl
+++ b/src/PathGraph.jl
@@ -14,8 +14,6 @@ using ..ColumnDefinitions:  ColumnDefinition,
                             make_column_def_child_copies
 import ..get_name
 
-export Node, SimpleNode, ValueNode, PathNode, get_name, get_children, get_all_value_nodes, get_default, make_path_graph, get_final_name
-
 # Nodes are keys in the graph of the data source. 
 @sum_type Node :hidden begin
     Path(::NameID, ::Vector{Node})

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,3 +1,4 @@
+# helper functions for inspecting types for container traits
 is_NameValueContainer(t) = typeof(StructTypes.StructType(t)) <: NameValueContainer
 is_container(t) = typeof(StructTypes.StructType(t)) <: Container
 is_value_type(t::Type) = !is_container(t) && isconcretetype(t)
@@ -37,6 +38,17 @@ end
 """Link a list of keys into an underscore separted column name"""
 join_names(names, joiner="_") = names .|> string |> (s -> join(s, joiner)) |> Symbol
 
+
+"""Collect an iterator into a tuple"""
+collect_tuple(itr) = _collect_tuple(safe_peel(itr))
+_collect_tuple(peel_return) = _collect_tuple(peel_return...)
+_collect_tuple(::Nothing) = ()
+_collect_tuple(val, rest) = (val, collect_tuple(rest)...)
+
+"""safe_peel(itr)
+Acts like Base.Iterators.peel, but 1) returns views instead of an Iterator.Rest and
+works across all Julia 1.X versions for empty containers
+"""
 function safe_peel(itr)
     len = length(itr)
     if len == 0
@@ -46,9 +58,3 @@ function safe_peel(itr)
     end
     return (first(itr), @view itr[2:end])
 end
-
-"""Collect an iterator into a tuple"""
-collect_tuple(itr) = _collect_tuple(safe_peel(itr))
-_collect_tuple(peel_return) = _collect_tuple(peel_return...)
-_collect_tuple(::Nothing) = ()
-_collect_tuple(val, rest) = (val, collect_tuple(rest)...)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -38,18 +38,17 @@ end
 join_names(names, joiner="_") = names .|> string |> (s -> join(s, joiner)) |> Symbol
 
 function safe_peel(itr)
-    try
-        return Iterators.peel(itr)
-    catch e
-        if e isa BoundsError
-            return nothing
-        end
-        throw(e)
+    len = length(itr)
+    if len == 0
+        return nothing
+    elseif len == 1
+        return (Iterators.only(itr), ())
     end
+    return (first(itr), @view itr[2:end])
 end
 
 """Collect an iterator into a tuple"""
 collect_tuple(itr) = _collect_tuple(safe_peel(itr))
 _collect_tuple(peel_return) = _collect_tuple(peel_return...)
 _collect_tuple(::Nothing) = ()
-_collect_tuple(val, rest::Iterators.Rest) = (val, collect_tuple(rest)...)
+_collect_tuple(val, rest) = (val, collect_tuple(rest)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,6 @@ end
 
 
 @testset "ExpandNestedData" begin
-
     @testset "Internals" begin
         @testset "NestedIterators and ColumnSets" begin
             csm = ExpandNestedData.ColumnSetManager()


### PR DESCRIPTION
This PR removes all exports from internal modules and replaces them with explicit imports where the function is needed. It also updates the internals test suite to match the new conventions.

It also has some small tweaks to NestedIterators to reduce allocs and improved docstrings/comments for internals