### PR TITLE
Fix/mismatched_column_lengths

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Micah Rufsvold <mjrufsvold@protonmail.com>"]
 version = "1.1.2"
 
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExpandNestedData"
 uuid = "8a7d223a-a7dc-4abf-8bc1-b0ce2ace9adc"
 authors = ["Micah Rufsvold <mjrufsvold@protonmail.com>"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/ColumnSetManager.jl
+++ b/src/ColumnSetManager.jl
@@ -259,9 +259,7 @@ end
     build_final_column_set(csm::ColumnSetManager, raw_cs)
 Take a ColumnSet with ID keys and reconstruct a column_set with actual names keys
 """
-function build_final_column_set(csm::ColumnSetManager, raw_cs)
-    # todo -- we could track the longest field_path and then make the tuple length known
-    # todo -- can the final columnset be changed to symbols at this point?
+function build_final_column_set(csm::ColumnSetManager, raw_cs::ColumnSet)
     final_cs = OrderedRobinDict{Tuple, NestedIterator}()
     for (raw_id, column) in pairs(raw_cs)
         field_path = reconstruct_field_path(csm, raw_id)

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -276,7 +276,8 @@ function stack_cols!(column_set_num, column_stack, default_col, csm)
     while !all(length(cs)==0 for cs in columns_to_stack)
         first_key = minimum(get_first_key, columns_to_stack)
         matching_cols = (pop!(cs, first_key, default_col) for cs in columns_to_stack)
-        push!(new_column_set, first_key=>foldl(vcat, matching_cols))
+        new_column = foldl(vcat, matching_cols)
+        push!(new_column_set, first_key=>new_column)
     end
 
     # free the column_sets that are no longer needed

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -139,7 +139,7 @@ function process_dict!(parent_name_list, data, node, instruction_stack, csm)
 
     for child_node in child_nodes
         name_id = get_name(child_node)
-        @debug "getting information for child" name=name node=child_node
+        @debug "getting information for child" node=child_node
         name_list = NameList(parent_name_list, name_id)
         # TODO we have to do this lookup twice (once to make id, once to get name back)
         # it would be better to zip up the name_ids with the values as they're constructed

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -237,7 +237,6 @@ each ColumnSet such that you get the Cartesian Product of their join.
 function merge_cols!(set_num, column_stack, csm)
     col_set = pop!(column_stack)
     multiplier = column_length(col_set)
-    x = 10
     for _ in 2:set_num
         new_col_set = pop!(column_stack)
         if length(new_col_set) == 0

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -236,7 +236,8 @@ each ColumnSet such that you get the Cartesian Product of their join.
 """
 function merge_cols!(set_num, column_stack, csm)
     col_set = pop!(column_stack)
-    multiplier = 1
+    multiplier = column_length(col_set)
+    x = 10
     for _ in 2:set_num
         new_col_set = pop!(column_stack)
         if length(new_col_set) == 0

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,4 +1,4 @@
-import .NestedIterators: RawNestedIterator, NestedVcat
+import .NestedIterators: RawNestedIterator
 import .ColumnSetManagers: ColumnSet, cycle_columns_to_length!, repeat_each_column!, get_first_key, 
                 get_total_length, column_length, set_length!, free_column_set!, build_final_column_set
 import .PathGraph: make_path_graph, get_children, SimpleNode
@@ -36,7 +36,6 @@ function expand(data, column_definitions=nothing;
         column_names::Dict = Dict{Tuple, Symbol}(),
         column_style::Symbol=:flat, 
         name_join_pattern = "_")
-
     typed_column_style = get_column_style(column_style)
     csm = ColumnSetManager()
     path_graph = make_path_graph(csm, column_definitions)
@@ -263,7 +262,6 @@ If a column name is present in one set but not in the other, then insert a defau
 """
 function stack_cols!(column_set_num, column_stack, default_col, csm)
     columns_to_stack = @view column_stack[end-column_set_num+1:end]
-
     new_column_set = get_column_set(csm)
     total_len = get_total_length(columns_to_stack)
     set_length!(new_column_set, total_len)
@@ -272,11 +270,10 @@ function stack_cols!(column_set_num, column_stack, default_col, csm)
     # We go down each columnset and check if it has a matching key.
     # From there, we either pop! the column if the key matches or create a default column and add
     # it to the stack
-    vcat = NestedVcat(csm)
     while !all(length(cs)==0 for cs in columns_to_stack)
         first_key = minimum(get_first_key, columns_to_stack)
         matching_cols = (pop!(cs, first_key, default_col) for cs in columns_to_stack)
-        new_column = foldl(vcat, matching_cols)
+        new_column = vcat(matching_cols...)
         push!(new_column_set, first_key=>new_column)
     end
 

--- a/src/NestedIterators.jl
+++ b/src/NestedIterators.jl
@@ -2,9 +2,12 @@ module NestedIterators
 using PooledArrays
 using SumTypes
 using Compat
+using Accessors
 using ..NameLists: NameID, no_name_id
 import ..get_name
 import ..get_id
+import ..make_switch
+import ..opcompose
 
 struct CaptureListNil end
 """A node in a linked list of captured iteration instructions"""
@@ -23,11 +26,11 @@ Base.iterate(::CaptureList, ::CaptureListNil) = nothing
     RawSeed(::NameID)
     RawRepeat(::Int64)
     RawCycle(::Int64)
-    RawVcat(::Int64, ::CaptureList{<:IterCapture}, ::CaptureList{<:IterCapture})
+    RawVcat(::Vector{Int64}, ::Vector{CaptureList{<:IterCapture}})
 end
 
 
-mutable struct RawNestedIterator
+struct RawNestedIterator
     get_index::Union{CaptureListNil,CaptureList}
     column_length::Int64
     el_type::Type
@@ -81,6 +84,10 @@ function Base.isequal(rni1::RawNestedIterator, rni2::RawNestedIterator, csm)
     end
     return isequal(collect(rni1, csm), collect(rni2, csm))
 end
+get_index_captures(rni::RawNestedIterator) = rni.get_index
+is_single_value(rni::RawNestedIterator) = rni.one_value
+get_unique_val(rni::RawNestedIterator) = rni.unique_val
+get_el_type(rni::RawNestedIterator) = rni.el_type
 
 
 """Seed is the core starter for a NestedIterator"""
@@ -100,12 +107,11 @@ end
 (u::UnrepeatEach)(i) = ceil(Int64, i/u.n)
 
 function repeat_each(c::RawNestedIterator, n)
+    @reset c.column_length = length(c) * n
     # when there is only one unique value, we can skip composing the repeat_each step
-    c.column_length *= n
-    if c.one_value
-        return c
-    end
-    c.get_index = CaptureList(IterCapture'.RawRepeat(n), c.get_index)
+    c.one_value && return c
+
+    @reset c.get_index = CaptureList(IterCapture'.RawRepeat(n), c.get_index)
     return c
 end
 
@@ -117,80 +123,48 @@ end
 """cycle(c, n) cycles through an array N times"""
 function cycle(c::RawNestedIterator, n)
     original_len = c.column_length
+    @reset c.column_length = original_len * n
+    
     # when there is only one unique value, we can skip composing the uncycle step
-    c.column_length *= n
-    if c.one_value
-        return c
-    end
-    c.get_index = CaptureList(IterCapture'.RawCycle(original_len), c.get_index)
+    c.one_value && return c
+
+    @reset c.get_index = CaptureList(IterCapture'.RawCycle(original_len), c.get_index)
     return c
 end
 
 """Captures the two getindex functions of vcated NestedIterators. f_len tells which index to break over to g."""
-struct Unvcat{F, G} 
-    f_len::Int64
+struct Unvcat{F}
     f::F
-    g::G 
 end
-(u::Unvcat)(i) = i > u.f_len ? u.g(i-u.f_len) : u.f(i)
+function Unvcat(csm, lengths, captures)
+    funcs = (build_get_index(csm, cap) for cap in captures)
+    f = make_switch(funcs, lengths)
+    return Unvcat{typeof(f)}(f)
+end
+(u::Unvcat)(i) = u.f(i)
 
-"""vcat(csm::ColumnSetManger, c1::RawNestedIterator, c2::RawNestedIterator)
-Return a single NestedIterator which is the result of vcat(c1,c2)
+"""vcat(iters::RawNestedIterator...)
+Return a single RawNestedIterator which is the result of stacking the iterators
 """
-function _vcat(csm, c1::RawNestedIterator, c2::RawNestedIterator)
-    c1_len = length(c1)
-    c2_len = length(c2)
-    c1_len == 0 && return c2
-    c2_len == 0 && return c1
-    len = c1_len + c2_len
-    
-    T1 = c1.el_type
-    T2 = c2.el_type
+function Base.vcat(iters::RawNestedIterator...)
+    lengths = length.(iters)
+    len = sum(lengths)
 
-    only_one_value = if T1 === T2 && c1.one_value && c2.one_value
-        v1 = get_single_value(csm, c1.unique_val, T1)
-        v2 = get_single_value(csm, c2.unique_val, T1)
-        isequal(v1, v2)
-    else
-        false
+    if all(is_single_value, iters) && allequal(Iterators.map(get_unique_val, iters))
+        iter = first(iters)
+        return @set iter.column_length = len
     end
 
-    only_one_value && return RawNestedIterator(c1.get_index, len, T1, true, c1.unique_val)
-    
-    type = Union{T1, T2}
-        
-    return RawNestedIterator(
-        CaptureList(IterCapture'.RawVcat(c1_len, c1.get_index, c2.get_index)),
-        len, type, false, no_name_id
-    )
-end
-"""Get a value stored in the ColumnSetManager and assert the return type of the value"""
-get_single_value(csm, id, ::Type{T}) where T = first(get_name(csm, id))::T
+    caps_list = collect(get_index_captures.(iters))
+    type = Union{(getproperty(iter,:el_type) for iter in iters)...}
 
-"""Callable struct that stores a ColumnSetManager to allow a two arg function for vcat-ing RawNestedIterators with folds"""
-struct NestedVcat{T} <: Function
-    csm::T
-end
-(v::NestedVcat)(c1,c2) = _vcat(v.csm, c1, c2)
-(v::NestedVcat)(c1) = c1
-
-"""Compose a get_index function out of the list of captured instructions from a RawNestedIterator"""
-function build_get_index(csm, captures)
-    iter_funcs = Iterators.map(cap -> get_iter_func(csm, cap), captures)
-    return foldl((f,g) -> g ∘ f, iter_funcs)
+    RawNestedIterator(
+        CaptureList(IterCapture'.RawVcat(collect(lengths), caps_list)), len, type, false, no_name_id)
 end
 
-"""Construct the correct iterator capture function for the given IterCapture"""
-function get_iter_func(csm, capture::IterCapture)
-    @cases capture begin
-        RawSeed(id) => Seed(get_name(csm, id))
-        RawRepeat(n) => UnrepeatEach(n)
-        RawCycle(n) => Uncycle(n)
-        RawVcat(len, iter1, iter2) => Unvcat(len, build_get_index(csm, iter1), build_get_index(csm, iter2))
-    end
-end
 
-"""NestedIterator is a container for instructions that build columns"""
+"""NestedIterator is a finalized column with a custom function to reproduce the order 
+that the data was found and unpacked"""
 struct NestedIterator{T,F} <: AbstractArray{T, 1}
     get_index::F
     column_length::Int64
@@ -207,6 +181,24 @@ Base.length(ni::NestedIterator) = ni.column_length
 Base.size(ni::NestedIterator) = (ni.column_length,)
 Base.getindex(ni::NestedIterator, i) = ni.get_index(i)
 Base.eachindex(ni::NestedIterator) = 1:length(ni)
-Base.collect(x::NestedIterator, pool_arrays=false) = pool_arrays ? PooledArray(x) : Vector(x)
+Base.collect(x::NestedIterator, pool_arrays=false) = Base.invokelatest(_collect, x, pool_arrays)
+_collect(x, pool_arrays) = pool_arrays ? PooledArray(x) : Vector(x)
+
+"""Compose a get_index function out of the list of captured instructions from a RawNestedIterator"""
+function build_get_index(csm, captures)
+    f = (cap) -> get_iter_func(csm, cap)
+    return mapfoldl(f, opcompose, captures)
+end
+
+"""Construct the correct iterator capture function for the given IterCapture"""
+function get_iter_func(csm, capture::IterCapture)
+    @cases capture begin
+        RawSeed(id) => Seed(get_name(csm, id))
+        RawRepeat(n) => UnrepeatEach(n)
+        RawCycle(n) => Uncycle(n)
+        RawVcat(lengths, captures_lists) => Unvcat(csm, lengths, captures_lists)
+    end
+end
+
 
 end #NestedIterators

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -334,6 +334,21 @@ end
             unordered_equal(ExpandNestedData.expand(input), output)
         end
 
+        # Test multiple missing columns in array
+        @test begin
+            input = [
+                Dict(:a=>1),
+                Dict(:a=>2),
+                Dict(:a=>3),
+                Dict(:a=>4, :b =>5),
+            ]
+            output = (
+                a = [1,2,3,4],
+                b = [missing,missing,missing,5]
+            )
+            unordered_equal(ExpandNestedData.expand(input), output)
+        end
+
         # Using struct of struct as input
         @test begin
             expected_table_expanded = (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -321,13 +321,26 @@ end
             unordered_equal(actual_expanded_table, expected_table_expanded)
         end
 
+        # Test mismatched Array length
+        @test begin
+            input = Dict(
+                :arr1 => [1,2,3],
+                :arr2 => [4,5]
+            )
+            output = (
+                arr1 = [1,1,2,2,3,3],
+                arr2 = [4,5,4,5,4,5]
+            )
+            unordered_equal(ExpandNestedData.expand(input), output)
+        end
+
         # Using struct of struct as input
         @test begin
             expected_table_expanded = (
                 new_column=[1,2,3,4,nothing], 
                 a_c=[2,nothing,1,1, nothing], 
                 d=[4,4,4,4,4])
-                unordered_equal(
+            unordered_equal(
                 ExpandNestedData.expand(struct_body; default_value=nothing, column_names= Dict((:a, :b) => :new_column)), 
                 expected_table_expanded)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,7 +53,11 @@ end
 function unordered_equal(t1, t2)
     fields = keys(t1)
     len = length(t1[1])
-    Set(get_rows(t1, fields,len)) == Set(get_rows(t2, fields,len))
+    matches = Set(get_rows(t1, fields,len)) == Set(get_rows(t2, fields,len))
+    if !matches
+        @show t1 t2
+    end
+    return matches
 end
 
 function all_equal(arr)
@@ -81,8 +85,7 @@ end
             @test [1,2] == collect(iter1_2(), csm)
             @test [1,2,1,2] == collect(NestedIterators.cycle(iter1_2(), 2), csm)
             @test [1,1,2,2] == collect(NestedIterators.repeat_each(iter1_2(), 2), csm)
-            ex_vcat = NestedIterators.NestedVcat(csm)
-            @test [1,2,1,2] == collect(ex_vcat(iter1_2(), iter1_2()), csm)
+            @test [1,2,1,2] == collect(vcat(iter1_2(), iter1_2()), csm)
             col_set = ExpandNestedData.ColumnSet(
                 NameLists.NameID(2) => NestedIterators.RawNestedIterator(csm, [3,4,5,6]),
                 NameLists.NameID(1) => NestedIterators.RawNestedIterator(csm, [1,2]),


### PR DESCRIPTION
Previously, the logic for merging the children of a dictionary incorrectly assumed that the first child would have length 1. We now check the length and start the cycle multiplier at that length.

There was a correctness bug due to mutating the RawNestedIterators during stacking. They are now immutable structs.

Also, constructing the switch statement for the vcat was painfully slow. It is now done with metaprogramming and `eval` and is much faster.